### PR TITLE
Intruduced basic CMake configuration

### DIFF
--- a/BoostCoreConfig.cmake
+++ b/BoostCoreConfig.cmake
@@ -1,0 +1,8 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+include(CMakeFindDependencyMacro)
+find_dependency(BoostConfig 1.66)
+find_dependency(BoostAssert 1.66)
+include("${CMAKE_CURRENT_LIST_DIR}/BoostCoreTargets.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,50 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+project(BoostCore VERSION 1.66 LANGUAGES CXX)
+
+add_library(core INTERFACE)
+
+target_include_directories(core INTERFACE 
+    $<BUILD_INTERFACE:${BoostCore_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${BoostCore_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    )
+
+find_package(BoostAssert 1.66 REQUIRED)
+find_package(BoostConfig 1.66 REQUIRED)
+
+target_link_libraries(core
+    INTERFACE
+        Boost::assert
+        Boost::config
+    )
+
+install(EXPORT core-targets
+    FILE BoostCoreTargets.cmake
+    NAMESPACE Boost::
+    DESTINATION lib/cmake/boost
+    )
+
+install(TARGETS core EXPORT core-targets
+    INCLUDES DESTINATION include
+    )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("BoostCoreConfigVersion.cmake"
+    VERSION ${BoostCore_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+install(
+    FILES
+        "BoostCoreConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/BoostCoreConfigVersion.cmake"
+    DESTINATION
+        lib/cmake/boost
+    )
+install(DIRECTORY include/ DESTINATION include)
+
+add_library(Boost::core ALIAS core)


### PR DESCRIPTION
Expresses Boost::core as an `INTERFACE` library in CMake.
- use via `add_subdirectory` 
- use via `find_package(BoostCore 1.66)` if previously installed. This is achieved via the following install:
```
$INSTALL_PREFIX
├── include
│   └── boost
│       ├── checked_delete.hpp
│       ├── core
│       │   ├── addressof.hpp
│       │   ├── checked_delete.hpp
│       │   ├── demangle.hpp
│       │   ├── enable_if.hpp
│       │   ├── explicit_operator_bool.hpp
│       │   ├── ignore_unused.hpp
│       │   ├── is_same.hpp
│       │   ├── lightweight_test.hpp
│       │   ├── lightweight_test_trait.hpp
│       │   ├── no_exceptions_support.hpp
│       │   ├── noncopyable.hpp
│       │   ├── null_deleter.hpp
│       │   ├── pointer_traits.hpp
│       │   ├── ref.hpp
│       │   ├── scoped_enum.hpp
│       │   ├── swap.hpp
│       │   ├── typeinfo.hpp
│       │   └── underlying_type.hpp
│       ├── detail
│       │   ├── iterator.hpp
│       │   ├── lightweight_test.hpp
│       │   ├── no_exceptions_support.hpp
│       │   ├── scoped_enum_emulation.hpp
│       │   └── sp_typeinfo.hpp
│       ├── get_pointer.hpp
│       ├── iterator.hpp
│       ├── noncopyable.hpp
│       ├── non_type.hpp
│       ├── ref.hpp
│       ├── swap.hpp
│       ├── type.hpp
│       ├── utility
│       │   ├── addressof.hpp
│       │   ├── enable_if.hpp
│       │   ├── explicit_operator_bool.hpp
│       │   └── swap.hpp
│       └── visit_each.hpp
└── lib
    └── cmake
        └── boost
            ├── BoostCoreConfig.cmake
            ├── BoostCoreConfigVersion.cmake
            └── BoostCoreTargets.cmake

8 directories, 39 files
```
- tests are __not__ included in the build